### PR TITLE
Fixed leaderboard name size truncates string to 10 characters

### DIFF
--- a/cgames/app.py
+++ b/cgames/app.py
@@ -40,7 +40,7 @@ def leaderboard():
 def submit_score():
     print(request.form)
 
-    name = request.form['name']
+    name = request.form['name'][0:10]
     score = int(request.form['score'])
     quiz = int(request.form['quiz'])
 


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the title above. -->

## Description
<!-- Describe your changes. The more detail you provide, the better. -->
Cuts the username to only 10 characters. 
## Related issues
<!-- This project only accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If you're fixing a bug, there should be an issue describing it with reproduction steps. -->
<!-- Please link to the issues as described here: https://help.github.com/articles/closing-issues-using-keywords/ -->
closes #83 
## Motivation
<!-- Why is this change required? What does it solve? -->
a user could put any number of characters into the leader board making it pretty messy 
## Types of changes
<!-- What types of changes does your code introduce? Put an "x" in all the boxes that apply. -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (something else not covered above)

## Checklist
<!-- Go over all the following points, and put an "x" in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Anything else
<!-- If you have anything else to say, write it below. -->
